### PR TITLE
README: Correct the instructions for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ You can find more information about the error handling APIs in the [documentatio
 You can build this project with all supported [Mbed OS build tools](https://os.mbed.com/docs/mbed-os/latest/tools/index.html). However, this example project specifically refers to the command-line interface tool [Arm Mbed CLI](https://github.com/ARMmbed/mbed-cli#installing-mbed-cli):
 
 1. Install Mbed CLI.
-1. Clone this repository on your system.
-1. Change the current directory to where the project was cloned.
+1. From the command-line, import the example: `mbed import mbed-os-example-error-handling`
+1. Change the current directory to where the project was imported.
 
 ## Application functionality
 


### PR DESCRIPTION
Added the missing instructions about deploying this example, so that the instructions may be followed and result in working software.