### PR TITLE
Update for mbed-os-6.8.0

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#0c6753bb821612eb72b5f682aed7ffcc98e80a1f
+https://github.com/ARMmbed/mbed-os/#26606218ad9d1ee1c8781aa73774fd7ea3a7658e

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#66c05ddbf8da7873108494ec9d243c2d2ca6a283
+https://github.com/ARMmbed/mbed-os/#f2278567d09b9ae9f4843e1d9d393526b9462783


### PR DESCRIPTION
This pull request updates the example to be compatible with the 
mbed-os-6.8.0 release of mbed-os. 