### PR TITLE
Fix CMake build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,9 @@ matrix:
         - pip install "Jinja2>=2.10.1,<2.11"
         - pip install "intelhex>=1.3,<=2.2.1"
       script:
-        - mbedtools checkout
-        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
-        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools deploy
+        - echo mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 
     - <<: *cmake-build-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,6 @@ add_subdirectory(${MBED_PATH})
 
 add_executable(${APP_TARGET})
 
-mbed_configure_app_target(${APP_TARGET})
-
-mbed_set_mbed_target_linker_script(${APP_TARGET})
-
 project(${APP_TARGET})
 
 target_sources(${APP_TARGET}

--- a/README.md
+++ b/README.md
@@ -5,9 +5,18 @@ This example shows how Mbed OS error handling works on an Mbed OS enabled platfo
 
 You can find more information about the error handling APIs in the [documentation](https://os.mbed.com/docs/mbed-os/latest/apis/error-handling.html).
 
-You can build this project with all supported [Mbed OS build tools](https://os.mbed.com/docs/mbed-os/latest/tools/index.html). However, this example project specifically refers to the command-line interface tool [Arm Mbed CLI](https://github.com/ARMmbed/mbed-cli#installing-mbed-cli):
+You can build the project with all supported [Mbed OS build tools](https://os.mbed.com/docs/mbed-os/latest/tools/index.html). However, this example project specifically refers to the command-line interface tools, [Arm Mbed CLI 1](https://github.com/ARMmbed/mbed-cli#installing-mbed-cli) and [Mbed CLI 2](https://github.com/ARMmbed/mbed-tools#installation).
 
-1. Install Mbed CLI.
+## Mbed OS build tools
+
+### Mbed CLI 2
+Starting with version 6.5, Mbed OS uses Mbed CLI 2. It uses Ninja as a build system, and CMake to generate the build environment and manage the build process in a compiler-independent manner. If you are working with Mbed OS version prior to 6.5 then check the section [Mbed CLI 1](#mbed-cli-1).
+1. [Install Mbed CLI 2](https://os.mbed.com/docs/mbed-os/latest/build-tools/install-or-upgrade.html).
+1. From the command-line, import the example: `mbed-tools import mbed-os-example-error-handling`
+1. Change the current directory to where the project was imported.
+
+### Mbed CLI 1
+1. [Install Mbed CLI 1](https://os.mbed.com/docs/mbed-os/latest/quick-start/offline-with-mbed-cli.html).
 1. From the command-line, import the example: `mbed import mbed-os-example-error-handling`
 1. Change the current directory to where the project was imported.
 
@@ -29,23 +38,39 @@ The example shows how to use the following APIs:
 1. Connect a USB cable between the USB port on the target and the host computer.
 1. Run this command to build the example project and program the microcontroller flash memory:
 
+    * Mbed CLI 2
+
+    ```bash
+    $ mbed-tools compile -m <TARGET> -t <TOOLCHAIN> --flash --sterm
+    ```
+
+    * Mbed CLI 1
+
     ```bash
     $ mbed compile -m <TARGET> -t <TOOLCHAIN> --flash --sterm
     ```
 
-(Note: You can use the Mbed CLI command-line option "--sterm" to open a serial terminal after flashing.)
 
 Your PC may take a few minutes to compile your code.
 
-The binary is located at `./BUILD/<TARGET>/<TOOLCHAIN>/mbed-os-example-error-handling.bin`.
+The binary is located at:
+* **Mbed CLI 2** - `./cmake_build/<TARGET>/develop/<TOOLCHAIN>/mbed-os-example-error-handling.bin`
 
-Alternatively, you can manually copy the binary to the target, which gets mounted on the host computer through USB.
+* **Mbed CLI 1** - `./BUILD/<TARGET>/<TOOLCHAIN>/mbed-os-example-error-handling.bin`
 
-Depending on the target, you can build the example project with the `GCC_ARM`, `ARM` or `IAR` toolchain. After installing Arm Mbed CLI, run the command below to determine which toolchain supports your target:
+You can manually copy the binary to the target, which gets mounted on the host computer through USB, rather than using the `--flash` option.
 
-```bash
-$ mbed compile -S
-```
+You can also open a serial terminal separately, rather than using the `--sterm` option, with the following command:
+* Mbed CLI 2 
+	```bash
+	$ mbed-tools sterm
+	```
+
+* Mbed CLI 1
+	```bash
+	$ mbed sterm
+    ```
+
 
 ## Expected output
 

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#f2278567d09b9ae9f4843e1d9d393526b9462783
+https://github.com/ARMmbed/mbed-os/


### PR DESCRIPTION
Changes have been made in Mbed CLI 2 and the CMake implementation in Mbed, and this example has not been updated accordingly, resulting in it failing to build. `.travis.yml` is updated to use the current mbed-tools commands, and deprecated CMake is removed from `CMakeLists.txt`. Instructions are added to `README.md` for the example with Mbed CLI 2.

Fixes #72 